### PR TITLE
README: Instructions cause you to run prepare script twice 

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ Install dependencies:
 
 ```shell
 npm install
-npm run prepare
 ```
 
 Once the modules are installed, just run a web server. Thanks to


### PR DESCRIPTION
This is awesome! So happy that @pika/web worked out for you on this project, if you have any feedback after using it we'd love to hear it over on https://github.com/pikapkg/web

Just a small suggestion for the docs: npm will run `prepare` for you automatically after `npm install`, so you don't need to run it a second time yourself. More info here: https://docs.npmjs.com/misc/scripts