### PR TITLE
Add -webkit prefix for Safari

### DIFF
--- a/src/change-mask.js
+++ b/src/change-mask.js
@@ -19,6 +19,7 @@ document.querySelector('.masks').addEventListener('change', evt => {
         masked.forEach(mask => {
             // When the radio buttons are selected,
             // change the clip path to the new mask.
+            mask.style.webkitClipPath = defaultMasks[radio.value];
             mask.style.clipPath = defaultMasks[radio.value];
         });
     }

--- a/style.css
+++ b/style.css
@@ -114,8 +114,9 @@ input.focus + label.button--primary {
 }
 .icon__mask,
 .icon__shadow {
+    -webkit-clip-path: inset(6.36% round 50%);
     clip-path: inset(6.36% round 50%);
-    transition: clip-path 0.3s ease;
+    transition: clip-path 0.3s ease, -webkit-clip-path 0.3s ease;
 }
 .icon__shadow {
     z-index: -1;


### PR DESCRIPTION
In Safari clip-path is [not currently supported](https://caniuse.com/#feat=css-clip-path) so the radio buttons don't mask the icon properly

![](https://user-images.githubusercontent.com/19822240/64016410-a09c2580-cb2f-11e9-97b7-e79992aacb3b.gif)

This PR adds `-webkit-` prefixes to add support to Safari