### PR TITLE
Add border-radius based compat mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,6 +75,18 @@
             name="og:description"
             content="Preview maskable icons in the browser!"
         />
+
+        <style>
+            .mask--path {
+                display: none;
+            }
+            @supports (clip-path: url(#squircle)) or
+                (-webkit-clip-path: url(#squircle)) {
+                .show-secrets .mask--path {
+                    display: inline-block;
+                }
+            }
+        </style>
     </head>
 
     <body>
@@ -244,7 +256,7 @@
                         />
                         Square
                     </label>
-                    <label class="mask__option secret">
+                    <label class="mask__option mask--path">
                         <input
                             type="radio"
                             name="mask"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
         "build": "npm run prepare -- --optimize && npm run minify:js && npm run minify:css && npm run sw",
         "prepare": "pika install",
         "sw": "workbox generateSW workbox-config.js",
-        "minify:css": "sqwish style.css -o style.css --strict",
+        "minify:css": "sqwish style.css -o style.css",
         "minify:js": "find . -maxdepth 2 -iname \"*.js\" -exec terser --compress --mangle --module -o {} -- {} \\;",
         "gzip": "gzip -k9nr ."
     },

--- a/src/change-mask.js
+++ b/src/change-mask.js
@@ -6,24 +6,48 @@ const defaultMasks = {
     sharp_rect: 'inset(6.36%)',
     drop: 'inset(6.36% round 50% 50% 34px)',
     minimum: 'inset(10% round 50%)',
-    squircle: 'url(#squircle)'
+    squircle: 'url(#squircle)',
 };
+const borderRadiiAndScale = {
+    none: ['0', 'scale(1)'],
+    circle: ['50%', 'scale(1.15)'],
+    rounded_rect: ['34px', 'scale(1.15)'],
+    sharp_rect: ['0', 'scale(1.15)'],
+    drop: ['50% 50% 34px', 'scale(1.15)'],
+    minimum: ['50%', 'scale(1.25)'],
+};
+
+const maskSupport = CSS.supports(
+    '(clip-path: inset(0)) or (-webkit-clip-path: inset(0))',
+);
 
 /** @type {HTMLElement} */
 const container = document.querySelector('.icon__grid');
 /** @type {NodeListOf<HTMLElement>} All elements to change the mask of. */
 const masked = document.querySelectorAll('.masked');
+/** @type {NodeListOf<HTMLElement>} */
+const icons = document.querySelectorAll('.icon');
 
 document.querySelector('.masks').addEventListener('change', evt => {
     const radio = /** @type {HTMLInputElement} */ (evt.target);
     if (radio.name === 'mask') {
-        const clipPath = defaultMasks[radio.value];
-        masked.forEach(mask => {
-            // When the radio buttons are selected,
-            // change the clip path to the new mask.
-            mask.style.webkitClipPath = clipPath;
-            mask.style.clipPath = clipPath;
-        });
+        if (maskSupport) {
+            const clipPath = defaultMasks[radio.value];
+            masked.forEach(mask => {
+                // When the radio buttons are selected,
+                // change the clip path to the new mask.
+                mask.style.webkitClipPath = clipPath;
+                mask.style.clipPath = clipPath;
+            });
+        } else {
+            const [borderRadius, scale] = borderRadiiAndScale[radio.value];
+            icons.forEach(icon => {
+                icon.style.transform = scale;
+            })
+            masked.forEach(mask => {
+                mask.style.borderRadius = borderRadius;
+            });
+        }
     }
 });
 document.querySelector('.controls').addEventListener('change', evt => {

--- a/src/libs.js
+++ b/src/libs.js
@@ -25,9 +25,8 @@ toggle.addEventListener('colorschemechange', () => {
 });
 
 if (new URL(location.href).searchParams.has('secret')) {
-    body.classList.add('show-secrets')
+    body.classList.add('show-secrets');
 }
-
 
 window.dataLayer = window.dataLayer || [];
 function gtag() {
@@ -42,4 +41,4 @@ gtag('config', 'UA-37324002-6');
 document.querySelector('.source__link').addEventListener('click', evt => {
     const link = /** @type {HTMLAnchorElement} */ (evt.currentTarget);
     gtag('event', 'view_item', { items: [{ id: link.href }] });
-})
+});

--- a/style.css
+++ b/style.css
@@ -114,20 +114,35 @@ input.focus + label.button--primary {
 }
 .icon__mask,
 .icon__shadow {
-    -webkit-clip-path: inset(6.36% round 50%);
-    clip-path: inset(6.36% round 50%);
-    transition: clip-path 0.3s ease, -webkit-clip-path 0.3s ease;
+    border-radius: 50%;
+    overflow: hidden;
+    transition: border-radius 0.3s ease;
+}
+.icon {
+    display: block;
+    width: 100%;
+    height: 100%;
+    transform: scale(1.15);
+    transition: transform 0.3s ease;
+}
+@supports (clip-path: inset(0)) or (-webkit-clip-path: inset(0)) {
+    .icon__mask,
+    .icon__shadow {
+        border-radius: 0px;
+        -webkit-clip-path: inset(6.36% round 50%);
+        clip-path: inset(6.36% round 50%);
+        transition: clip-path 0.3s ease, -webkit-clip-path 0.3s ease;
+    }
+    .icon {
+        transform: none;
+        transition: none;
+    }
 }
 .icon__shadow {
     z-index: -1;
 
     background: rgba(0, 0, 0, 0.2);
     transform: scale(1.01) translateY(1px);
-}
-.icon {
-    display: block;
-    width: 100%;
-    height: 100%;
 }
 .icon__original {
     opacity: 0;
@@ -174,17 +189,11 @@ dark-mode-toggle {
 
 @media (prefers-reduced-motion: reduce) {
     .drop,
+    .icon,
     .icon__grid,
     .icon__mask,
     .icon__shadow,
     .icon__original {
         transition: none;
     }
-}
-
-.secret {
-    display: none;
-}
-.show-secrets .secret {
-    display: inline-block;
 }


### PR DESCRIPTION
This adds support for Edge and some older browsers that don't support `clip-path`. The fallback uses a combination of `border-radius` and `transform: scale` to support the inset-based masks. The secret squircle mask isn't supported in this fallback.