### PR TITLE
Add 72 and 96px checkboxes to export options

### DIFF
--- a/editor.html
+++ b/editor.html
@@ -280,6 +280,14 @@
               48x48
             </label>
             <label class="mask__option">
+              <input type="checkbox" name="sizes" value="72" autocomplete="off" />
+              72x72
+            </label>
+            <label class="mask__option">
+              <input type="checkbox" name="sizes" value="96" autocomplete="off" />
+              96x96
+            </label>
+            <label class="mask__option">
               <input type="checkbox" name="sizes" value="128" autocomplete="off" />
               128x128
             </label>


### PR DESCRIPTION
Hi,

I just added the 72x72 and 96x96 options in the checkboxes in the export dialog. I believe that the code just checks the value, so this should work, but let me know if it doesn't, or if you prefer to not have those options for whatever reason.

Thank you.