### PR TITLE
Improving the image quality when shrinking large images.

### DIFF
--- a/src/editor/canvas.js
+++ b/src/editor/canvas.js
@@ -127,6 +127,15 @@ export function scaleCanvas(canvas, size, scale = 1) {
   canvas.width = size * scale;
   canvas.height = size * scale;
   const ctx = canvas.getContext('2d');
+  try {
+    // Try to improve the image quality when shrinking large images.
+    if (('imageSmoothingEnabled' in ctx))
+      ctx.imageSmoothingEnabled = true;
+    if (('imageSmoothingQuality' in ctx))
+      ctx.imageSmoothingQuality = 'high';
+  } catch (ex) {
+    // We will have to stick to the default behavior :(
+  }
   ctx.scale(scale, scale);
   return { canvas, ctx, size };
 }

--- a/src/editor/canvas.js
+++ b/src/editor/canvas.js
@@ -127,15 +127,9 @@ export function scaleCanvas(canvas, size, scale = 1) {
   canvas.width = size * scale;
   canvas.height = size * scale;
   const ctx = canvas.getContext('2d');
-  try {
-    // Try to improve the image quality when shrinking large images.
-    if ('imageSmoothingEnabled' in ctx)
-      ctx.imageSmoothingEnabled = true;
-    if ('imageSmoothingQuality' in ctx)
-      ctx.imageSmoothingQuality = 'high';
-  } catch (ex) {
-    // We will have to stick to the default behavior :(
-  }
+  // Try to improve the image quality when shrinking large images.
+  ctx.imageSmoothingEnabled = true;
+  ctx.imageSmoothingQuality = 'high';
   ctx.scale(scale, scale);
   return { canvas, ctx, size };
 }

--- a/src/editor/canvas.js
+++ b/src/editor/canvas.js
@@ -129,9 +129,9 @@ export function scaleCanvas(canvas, size, scale = 1) {
   const ctx = canvas.getContext('2d');
   try {
     // Try to improve the image quality when shrinking large images.
-    if (('imageSmoothingEnabled' in ctx))
+    if ('imageSmoothingEnabled' in ctx)
       ctx.imageSmoothingEnabled = true;
-    if (('imageSmoothingQuality' in ctx))
+    if ('imageSmoothingQuality' in ctx)
       ctx.imageSmoothingQuality = 'high';
   } catch (ex) {
     // We will have to stick to the default behavior :(


### PR DESCRIPTION
I added `ctx.imageSmoothingEnabled = true` and `ctx.imageSmoothingQuality = 'high'` to `scaleCanvas()`, which is the function that creates the canvas/context used for exporting images.

That way, shrunk exported images (should) have less visual artifacts, (hopefully) providing a better overall look.

If the browser does not support those settings, the previous/default behavior takes place.

I uploaded to my other repo two images comparing the results:

[With imageSmoothingEnabled = true](https://github.com/carlosrafaelgn/favicon/blob/master/comparison/maskable_icon_x48%20with%20imageSmoothing.png)

[Without imageSmoothingEnabled = true](https://github.com/carlosrafaelgn/favicon/blob/master/comparison/maskable_icon_x48%20without%20imageSmoothing.png)

[Original 512x512 image](https://github.com/carlosrafaelgn/neon/blob/master/favicons/favicon-512x512.png)

The reported failing test is actually a code style issue...

```
> format:check
> npm run format:base -- --check

> format:base
> prettier src/*/*.js lib/*.js tests/*/*.ts css/*.css *.{html,md,json} {workbox-,rollup.}config.js "--check"

Checking formatting...
[warn] src/editor/canvas.js
[warn] Code style issues found in the above file(s). Forgot to run Prettier?
Error: Process completed with exit code 1.
```

But I swear the 9 lines of code I added are according to the style! 😅

I closed pull request #47 because I thought it could be an issue with double parentheses, which I have just removed. But the tests failed again.

In fact, I removed those 9 lines locally, ran the test again (`npm run format:check`), and for my surprise, the test failed again. 😳
