### PR TITLE
Choose color by hex code feature added - #63

### DIFF
--- a/editor.html
+++ b/editor.html
@@ -239,7 +239,7 @@
           <label class="control">
             <span class="control__label">Color</span>
             <input class="control__input" type="color" name="fill" value="#448AFF" />
-            <span class="control__preview"></span>
+            <input type="text" name="fill" class="control__preview layer__name" />
           </label>
           <label class="control">
             <span class="control__label">Color strength</span>

--- a/src/editor/options.js
+++ b/src/editor/options.js
@@ -11,9 +11,9 @@ const fitInfo = document.querySelector('.info--fit');
  */
 export function updatePreview(input) {
   if (input.className !== 'control__input') return;
-  const preview = /** @type {HTMLSpanElement} */ (input.nextElementSibling);
-   if (input.name === 'fill') {
-     preview.value = input.value + (preview.dataset.suffix || '');
+  const preview = /** @type {HTMLSpanElement | HTMLInputElement} */ (input.nextElementSibling);
+  if (preview instanceof HTMLInputElement) {
+    preview.value = input.value + (preview.dataset.suffix || '');
   }else{
      preview.textContent = input.value + (preview.dataset.suffix || '');
   }

--- a/src/editor/options.js
+++ b/src/editor/options.js
@@ -12,7 +12,11 @@ const fitInfo = document.querySelector('.info--fit');
 export function updatePreview(input) {
   if (input.className !== 'control__input') return;
   const preview = /** @type {HTMLSpanElement} */ (input.nextElementSibling);
-  preview.textContent = input.value + (preview.dataset.suffix || '');
+   if (input.name === 'fill') {
+     preview.value = input.value + (preview.dataset.suffix || '');
+  }else{
+     preview.textContent = input.value + (preview.dataset.suffix || '');
+  }
 }
 
 /**


### PR DESCRIPTION
* Change the color preview span tag to input tag so that it could use as both, for showing preview as well as for taking color input in hex code.
* Styled the input tag, same as layer name input tag.