### PR TITLE
Add settings to control which masks show up

### DIFF
--- a/css/editor.css
+++ b/css/editor.css
@@ -92,6 +92,8 @@ input.focus + label.button--secondary {
   display: block;
   height: 100%;
   width: 100%;
+  position: relative;
+  fill: #ffbf1d;
   background-image: linear-gradient(
       45deg,
       rgba(0, 0, 0, 0.2) 25%,
@@ -102,6 +104,9 @@ input.focus + label.button--secondary {
     linear-gradient(-45deg, transparent 75%, rgba(0, 0, 0, 0.2) 75%);
   background-size: 16px 16px;
   background-position: 0 0, 0 8px, 8px -8px, -8px 0px;
+}
+.layer__preview--mask {
+  background-image: none;
 }
 .layer__name {
   grid-area: name;

--- a/css/settings.css
+++ b/css/settings.css
@@ -1,0 +1,17 @@
+.settings {
+  --columns: 2;
+  display: grid;
+  grid-template-columns: repeat(var(--columns), 1fr);
+  column-gap: 1rem;
+  max-width: 40rem;
+  margin: 0 auto;
+}
+.settings h3 {
+  grid-column: 1 / span var(--columns);
+}
+
+@media (max-width: 40rem) {
+  .settings {
+    --columns: 1;
+  }
+}

--- a/css/viewer.css
+++ b/css/viewer.css
@@ -343,3 +343,15 @@ hr {
     font-size: 8vw;
   }
 }
+
+.mask--path {
+  display: none;
+}
+@supports (clip-path: url(#squircle)) or (-webkit-clip-path: url(#squircle)) {
+  .mask--path {
+    display: inline-block;
+  }
+  .mask--path[hidden] {
+    display: none;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -16,24 +16,24 @@
     "minify:js:sw": "terser --compress --mangle --module -o sw.js -- sw.js"
   },
   "dependencies": {
-    "dark-mode-toggle": "^0.9.0",
+    "dark-mode-toggle": "^0.10.0",
     "file-drop-element": "^1.0.1"
   },
   "devDependencies": {
-    "@jest/globals": "^27.3.1",
+    "@jest/globals": "^27.4.6",
     "@rollup/plugin-multi-entry": "^4.1.0",
-    "@types/jest": "^27.0.2",
+    "@types/jest": "^27.4.0",
     "csso-cli": "^3.0.0",
-    "eslint": "^8.0.1",
+    "eslint": "^8.8.0",
     "eslint-config-prettier": "^8.3.0",
-    "jest": "^27.3.1",
-    "prettier": "~2.4.1",
-    "rollup": "^2.58.0",
+    "jest": "^27.4.7",
+    "prettier": "~2.5.1",
+    "rollup": "^2.66.1",
     "snowpack": "^1.7.1",
-    "terser": "^5.9.0",
-    "ts-jest": "^27.0.7",
+    "terser": "^5.10.0",
+    "ts-jest": "^27.1.3",
     "types-wm": "^1.1.0",
-    "typescript": "^4.4.4",
+    "typescript": "^4.5.5",
     "workbox-cli": "^6.3.0"
   },
   "prettier": {

--- a/settings.html
+++ b/settings.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <title>Maskable.app</title>
+    <title>Maskable.app Settings</title>
     <link href="css/viewer.css" rel="stylesheet" />
     <link href="https://fonts.googleapis.com/css2?family=Lato:wght@400;900&display=swap" rel="stylesheet" />
     <script type="module" src="src/viewer/libs.js"></script>
@@ -53,7 +53,7 @@
           <h1 class="title">Maskable​.app</h1>
 
           <nav class="navbar__links">
-            <a href="/" class="navbar__link navbar__link--active">Viewer</a>
+            <a href="/" class="navbar__link">Viewer</a>
             <a href="/editor" class="navbar__link">Editor</a>
             <a href="https://monochrome.fyi" class="navbar__link">
               Monochrome.fyi
@@ -79,198 +79,66 @@
           <dark-mode-toggle permanent></dark-mode-toggle>
         </header>
 
-        <div class="demo__container">
-          <ul class="demo__list">
-            <!--
-            Different sample icons that the user can look at.
-            The original source of the icon is linked in the data-source attribute.
-            The alt tag is used as the title of the source.
-          -->
-            <li class="demo">
-              <a class="demo__link" href="?demo=demo/spec.svg">
-                <img
-                  width="56"
-                  height="56"
-                  class="demo__preview"
-                  src="demo/spec.svg"
-                  alt="W3C example"
-                  data-source="https://www.w3.org/TR/appmanifest/#examples-of-masks"
-                />
-              </a>
-            </li>
-            <li class="demo">
-              <a class="demo__link" href="?demo=demo/color-breakdown.png">
-                <img
-                  width="56"
-                  height="56"
-                  class="demo__preview"
-                  src="demo/color-breakdown.png"
-                  alt="Color Breakdown"
-                  data-source="https://notwoods.github.io/color-breakdown/"
-                />
-              </a>
-            </li>
-            <li class="demo">
-              <a class="demo__link" href="?demo=demo/insightful-energy.svg">
-                <img
-                  width="56"
-                  height="56"
-                  class="demo__preview"
-                  src="demo/insightful-energy.svg"
-                  alt="Insightful Energy"
-                  data-source="https://notwoods.github.io/insightful-energy/"
-                />
-              </a>
-            </li>
-            <li class="demo">
-              <a class="demo__link" href="?demo=demo/big-island-buses.png">
-                <img
-                  width="56"
-                  height="56"
-                  class="demo__preview"
-                  src="demo/big-island-buses.png"
-                  alt="Big Island Buses"
-                  data-source="https://notwoods.github.io/big-island-buses/"
-                />
-              </a>
-            </li>
-            <li class="demo">
-              <a class="demo__link" href="?demo=demo/proxx.png">
-                <img
-                  width="56"
-                  height="56"
-                  class="demo__preview"
-                  src="demo/proxx.png"
-                  alt="PROXX"
-                  data-source="https://proxx.app"
-                />
-              </a>
-            </li>
-            <li class="demo">
-              <a class="demo__link" href="?demo=demo/svgomg.svg">
-                <img
-                  width="56"
-                  height="56"
-                  class="demo__preview"
-                  src="demo/svgomg.svg"
-                  alt="SVGOMG"
-                  data-source="https://jakearchibald.github.io/svgomg/"
-                />
-              </a>
-            </li>
-          </ul>
-
-          <input type="file" accept="image/*" class="hidden-offscreen" id="icon_file" name="icon_file" />
-          <label for="icon_file" class="icon__file-input button--primary"> Open icon file </label>
-
-          <details class="demo__url-container">
-            <summary class="button--primary">Load from URL</summary>
-            <form class="demo__url" action="/">
-              <label>
-                URL:
-                <input type="text" id="demo" name="url" placeholder="https://example.com/image.png" />
-              </label>
-              <input type="submit" value="Load" class="button--primary" />
-            </form>
-          </details>
-        </div>
-
-        <section class="icon__grid">
-          <div class="icon__original">
-            <img class="icon" alt="Preview of original icon" src="demo/spec.svg" />
-          </div>
-          <div class="icon__mask masked">
-            <img class="icon" alt="Preview of maskable icon" src="demo/spec.svg" />
-          </div>
-          <div class="icon__shadow masked"></div>
-        </section>
+        <h2>Settings</h2>
+        <hr />
 
         <section class="masks text">
           <!--
             Different options for the icon mask. Corresponds to the change-mask.js script.
           -->
-          <h3>Masks</h3>
+          <h3>Available Masks</h3>
           <label class="mask__option">
-            <input type="radio" name="mask" value="none" autocomplete="off" accesskey="1" />
+            <input type="checkbox" name="mask" value="none" checked autocomplete="off" accesskey="1" />
             None
           </label>
           <label class="mask__option">
-            <input type="radio" name="mask" value="minimum" checked autocomplete="off" accesskey="2" />
+            <input type="checkbox" name="mask" value="minimum" checked autocomplete="off" accesskey="2" />
             Minimum safe area
           </label>
           <label class="mask__option">
-            <input type="radio" name="mask" value="circle" autocomplete="off" accesskey="3" />
+            <input type="checkbox" name="mask" value="circle" checked autocomplete="off" accesskey="3" />
             Circle
           </label>
           <label class="mask__option">
-            <input type="radio" name="mask" value="rounded_rect" autocomplete="off" accesskey="4" />
+            <input type="checkbox" name="mask" value="rounded_rect" checked autocomplete="off" accesskey="4" />
             Rounded Rectangle
           </label>
           <label class="mask__option">
-            <input type="radio" name="mask" value="sharp_rect" autocomplete="off" accesskey="5" />
+            <input type="checkbox" name="mask" value="sharp_rect" checked autocomplete="off" accesskey="5" />
             Square
           </label>
           <label class="mask__option">
-            <input type="radio" name="mask" value="drop" autocomplete="off" accesskey="6" />
+            <input type="checkbox" name="mask" value="drop" checked autocomplete="off" accesskey="6" />
             Drop
           </label>
           <label class="mask__option">
-            <input type="radio" name="mask" value="cylinder" autocomplete="off" accesskey="7" />
+            <input type="checkbox" name="mask" value="cylinder" checked autocomplete="off" accesskey="7" />
             Cylinder
           </label>
           <label class="mask__option mask--path">
-            <input type="radio" name="mask" value="squircle" autocomplete="off" />
+            <input type="checkbox" name="mask" value="squircle" autocomplete="off" />
             Squircle
           </label>
           <label class="mask__option mask--path">
-            <input type="radio" name="mask" value="flower" autocomplete="off" />
+            <input type="checkbox" name="mask" value="flower" autocomplete="off" />
             Flower
           </label>
           <label class="mask__option mask--path">
-            <input type="radio" name="mask" value="pebble" autocomplete="off" />
+            <input type="checkbox" name="mask" value="pebble" autocomplete="off" />
             Pebble
           </label>
           <label class="mask__option mask--path">
-            <input type="radio" name="mask" value="vessel" autocomplete="off" />
+            <input type="checkbox" name="mask" value="vessel" autocomplete="off" />
             Vessel
           </label>
           <label class="mask__option mask--path">
-            <input type="radio" name="mask" value="hexagon" autocomplete="off" />
+            <input type="checkbox" name="mask" value="hexagon" autocomplete="off" />
             Hexagon
           </label>
         </section>
-        <section class="controls text">
-          <h3>Controls</h3>
-          <label class="mask__option">
-            <input type="checkbox" name="shrink" autocomplete="off" accesskey="*" />
-            Shrink
-          </label>
-          <label class="mask__option">
-            <input type="checkbox" name="ghost" autocomplete="off" accesskey="#" />
-            Show ghost image
-          </label>
-        </section>
-        <aside class="source text">
-          <p>
-            Icon from
-            <a href="https://www.w3.org/TR/appmanifest/#examples-of-masks" class="source__link"> W3C example </a>
-          </p>
-        </aside>
 
-        <hr />
         <aside class="about text">
           <div data-ea-publisher="maskableapp" data-ea-type="text"></div>
-          <p class="about__main">
-            Use Maskable.app to preview your maskable PWA icons before adding them to your web app manifest.
-          </p>
-          <p class="about__main">
-            <a class="about__link" href="https://css-tricks.com/maskable-icons-android-adaptive-icons-for-your-pwa/">
-              Maskable icons</a
-            >
-            allow web developers to specify a full-bleed icon that will be cropped by the user-agent to match other
-            icons on the device. On Android, this lets developers get rid of the default white background around their
-            icons and use the entire provided space by generating adaptive icons.
-          </p>
           <p class="about__extra">
             Edit on
             <a class="about__link" href="https://github.com/NotWoods/maskable"> GitHub </a>

--- a/settings.html
+++ b/settings.html
@@ -4,19 +4,19 @@
     <meta charset="UTF-8" />
     <title>Maskable.app Settings</title>
     <link href="css/viewer.css" rel="stylesheet" />
+    <link href="css/editor.css" rel="stylesheet" />
+    <link href="css/settings.css" rel="stylesheet" />
     <link href="https://fonts.googleapis.com/css2?family=Lato:wght@400;900&display=swap" rel="stylesheet" />
     <script type="module" src="src/viewer/libs.js"></script>
+    <script type="module" src="src/settings/mask-settings.js"></script>
     <script type="module" src="src/viewer/upload-icon.js"></script>
-    <script type="module" src="src/viewer/change-mask.js"></script>
     <script type="module" src="src/viewer/keys.js"></script>
-    <script nomodule src="src/mask-bundle.js" defer></script>
+    <script nomodule src="src/settings/mask-settings.js" defer></script>
     <script nomodule src="src/viewer-bundle.js" defer></script>
     <script nomodule src="src/libs-bundle.js" defer></script>
     <script async src="https://media.ethicalads.io/media/client/ethicalads.min.js"></script>
     <link rel="preload" href="toggle/sun.svg" as="image" />
     <link rel="preload" href="toggle/moon.svg" as="image" />
-    <link rel="modulepreload" href="src/viewer/masks.js" />
-    <link rel="modulepreload" href="/web_modules/file-drop-element.js" />
     <link rel="modulepreload" href="/web_modules/dark-mode-toggle.js" />
 
     <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -79,63 +79,180 @@
           <dark-mode-toggle permanent></dark-mode-toggle>
         </header>
 
-        <h2>Settings</h2>
-        <hr />
+        <form>
+          <h2>Settings</h2>
+          <hr />
 
-        <section class="masks text">
-          <!--
-            Different options for the icon mask. Corresponds to the change-mask.js script.
-          -->
-          <h3>Available Masks</h3>
-          <label class="mask__option">
-            <input type="checkbox" name="mask" value="none" checked autocomplete="off" accesskey="1" />
-            None
-          </label>
-          <label class="mask__option">
-            <input type="checkbox" name="mask" value="minimum" checked autocomplete="off" accesskey="2" />
-            Minimum safe area
-          </label>
-          <label class="mask__option">
-            <input type="checkbox" name="mask" value="circle" checked autocomplete="off" accesskey="3" />
-            Circle
-          </label>
-          <label class="mask__option">
-            <input type="checkbox" name="mask" value="rounded_rect" checked autocomplete="off" accesskey="4" />
-            Rounded Rectangle
-          </label>
-          <label class="mask__option">
-            <input type="checkbox" name="mask" value="sharp_rect" checked autocomplete="off" accesskey="5" />
-            Square
-          </label>
-          <label class="mask__option">
-            <input type="checkbox" name="mask" value="drop" checked autocomplete="off" accesskey="6" />
-            Drop
-          </label>
-          <label class="mask__option">
-            <input type="checkbox" name="mask" value="cylinder" checked autocomplete="off" accesskey="7" />
-            Cylinder
-          </label>
-          <label class="mask__option mask--path">
-            <input type="checkbox" name="mask" value="squircle" autocomplete="off" />
-            Squircle
-          </label>
-          <label class="mask__option mask--path">
-            <input type="checkbox" name="mask" value="flower" autocomplete="off" />
-            Flower
-          </label>
-          <label class="mask__option mask--path">
-            <input type="checkbox" name="mask" value="pebble" autocomplete="off" />
-            Pebble
-          </label>
-          <label class="mask__option mask--path">
-            <input type="checkbox" name="mask" value="vessel" autocomplete="off" />
-            Vessel
-          </label>
-          <label class="mask__option mask--path">
-            <input type="checkbox" name="mask" value="hexagon" autocomplete="off" />
-            Hexagon
-          </label>
-        </section>
+          <section class="settings text">
+            <h3>Available Masks</h3>
+            <ul class="layers__list">
+              <li class="layer">
+                <label class="layer__preview-button">
+                  <input
+                    name="mask"
+                    type="checkbox"
+                    disabled
+                    value="none"
+                    class="layer__radio"
+                    autocomplete="off"
+                    checked
+                  />
+                  <div
+                    class="layer__preview layer__preview--mask masked"
+                    style="-webkit-clip-path: inset(0); clip-path: inset(0)"
+                  >
+                    <img class="icon" alt="" src="demo/spec.svg" />
+                  </div>
+                  <span class="layer__name">None</span>
+                </label>
+              </li>
+              <li class="layer">
+                <label class="layer__preview-button">
+                  <input
+                    name="mask"
+                    type="checkbox"
+                    disabled
+                    value="minimum"
+                    class="layer__radio"
+                    autocomplete="off"
+                    checked
+                  />
+                  <div
+                    class="layer__preview layer__preview--mask masked"
+                    style="-webkit-clip-path: inset(10% round 50%); clip-path: inset(10% round 50%)"
+                  >
+                    <img class="icon" alt="" src="demo/spec.svg" />
+                  </div>
+                  <span class="layer__name">Minimum safe area</span>
+                </label>
+              </li>
+              <li class="layer">
+                <label class="layer__preview-button">
+                  <input name="mask" type="checkbox" value="circle" class="layer__radio" autocomplete="off" checked />
+                  <div
+                    class="layer__preview layer__preview--mask masked"
+                    style="-webkit-clip-path: inset(6.36% round 50%); clip-path: inset(6.36% round 50%)"
+                  >
+                    <img class="icon" alt="" src="demo/spec.svg" />
+                  </div>
+                  <span class="layer__name">Circle</span>
+                </label>
+              </li>
+              <li class="layer">
+                <label class="layer__preview-button">
+                  <input
+                    name="mask"
+                    type="checkbox"
+                    value="rounded_rect"
+                    class="layer__radio"
+                    autocomplete="off"
+                    checked
+                  />
+                  <div
+                    class="layer__preview layer__preview--mask masked"
+                    style="-webkit-clip-path: inset(6.36% round 11.33px); clip-path: inset(6.36% round 11.33px)"
+                  >
+                    <img class="icon" alt="" src="demo/spec.svg" />
+                  </div>
+                  <span class="layer__name">Rounded Rectangle</span>
+                </label>
+              </li>
+              <li class="layer">
+                <label class="layer__preview-button">
+                  <input
+                    name="mask"
+                    type="checkbox"
+                    value="sharp_rect"
+                    class="layer__radio"
+                    autocomplete="off"
+                    checked
+                  />
+                  <div
+                    class="layer__preview layer__preview--mask masked"
+                    style="-webkit-clip-path: inset(6.36%); clip-path: inset(6.36%)"
+                  >
+                    <img class="icon" alt="" src="demo/spec.svg" />
+                  </div>
+                  <span class="layer__name">Square</span>
+                </label>
+              </li>
+              <li class="layer">
+                <label class="layer__preview-button">
+                  <input name="mask" type="checkbox" value="drop" class="layer__radio" autocomplete="off" checked />
+                  <div
+                    class="layer__preview layer__preview--mask masked"
+                    style="
+                      -webkit-clip-path: inset(6.36% round 50% 50% 11.33px);
+                      clip-path: inset(6.36% round 50% 50% 11.33px);
+                    "
+                  >
+                    <img class="icon" alt="" src="demo/spec.svg" />
+                  </div>
+                  <span class="layer__name">Drop</span>
+                </label>
+              </li>
+              <li class="layer">
+                <label class="layer__preview-button">
+                  <input name="mask" type="checkbox" value="cylinder" class="layer__radio" autocomplete="off" checked />
+                  <div
+                    class="layer__preview layer__preview--mask masked"
+                    style="-webkit-clip-path: inset(6.36% round 50% / 30%); clip-path: inset(6.36% round 50% / 30%)"
+                  >
+                    <img class="icon" alt="" src="demo/spec.svg" />
+                  </div>
+                  <span class="layer__name">Cylinder</span>
+                </label>
+              </li>
+            </ul>
+            <ul class="layers__list">
+              <li class="layer">
+                <label class="layer__preview-button">
+                  <input name="mask" type="checkbox" value="squircle" class="layer__radio" autocomplete="off" />
+                  <svg class="layer__preview layer__preview--mask" height="64" width="64" viewBox="0 0 192 192">
+                    <image class="icon" width="192" height="192" href="demo/spec.svg" clip-path="url(#squircle)" />
+                  </svg>
+                  <span class="layer__name">Squircle</span>
+                </label>
+              </li>
+              <li class="layer">
+                <label class="layer__preview-button">
+                  <input name="mask" type="checkbox" value="flower" class="layer__radio" autocomplete="off" />
+                  <svg class="layer__preview layer__preview--mask" height="64" width="64" viewBox="0 0 192 192">
+                    <image class="icon" width="192" height="192" href="demo/spec.svg" clip-path="url(#flower)" />
+                  </svg>
+                  <span class="layer__name">Flower</span>
+                </label>
+              </li>
+              <li class="layer">
+                <label class="layer__preview-button">
+                  <input name="mask" type="checkbox" value="pebble" class="layer__radio" autocomplete="off" />
+                  <svg class="layer__preview layer__preview--mask" height="64" width="64" viewBox="0 0 192 192">
+                    <image class="icon" width="192" height="192" href="demo/spec.svg" clip-path="url(#pebble)" />
+                  </svg>
+                  <span class="layer__name">Pebble</span>
+                </label>
+              </li>
+              <li class="layer">
+                <label class="layer__preview-button">
+                  <input name="mask" type="checkbox" value="vessel" class="layer__radio" autocomplete="off" />
+                  <svg class="layer__preview layer__preview--mask" height="64" width="64" viewBox="0 0 192 192">
+                    <image class="icon" width="192" height="192" href="demo/spec.svg" clip-path="url(#vessel)" />
+                  </svg>
+                  <span class="layer__name">Vessel</span>
+                </label>
+              </li>
+              <li class="layer">
+                <label class="layer__preview-button">
+                  <input name="mask" type="checkbox" value="hexagon" class="layer__radio" autocomplete="off" />
+                  <svg class="layer__preview layer__preview--mask" height="64" width="64" viewBox="0 0 192 192">
+                    <image class="icon" width="192" height="192" href="demo/spec.svg" clip-path="url(#hexagon)" />
+                  </svg>
+                  <span class="layer__name">Hexagon</span>
+                </label>
+              </li>
+            </ul>
+          </section>
+        </form>
 
         <aside class="about text">
           <div data-ea-publisher="maskableapp" data-ea-type="text"></div>

--- a/src/settings/mask-settings.js
+++ b/src/settings/mask-settings.js
@@ -1,0 +1,48 @@
+// @ts-check
+
+const form = document.querySelector('form');
+
+/**
+ * Get shown masks from storage.
+ * Also ensures settings page checkboxes match current saved state.
+ * @returns {Set<string>}
+ */
+function loadShownMasks() {
+  const savedShownMasks = localStorage.getItem('shownMasks');
+  if (savedShownMasks != undefined) {
+    const savedHiddenMasksList = new Set(savedShownMasks.split(','));
+    /** @type {NodeListOf<HTMLInputElement>} */
+    const maskCheckboxes = form['mask'];
+    for (const mask of maskCheckboxes) {
+      mask.checked = savedHiddenMasksList.has(mask.value);
+    }
+    return savedHiddenMasksList;
+  } else {
+    /** @type {NodeListOf<HTMLInputElement>} */
+    const checkedMasks = form.querySelectorAll('input[name="mask"]:checked');
+    return new Set(Array.from(checkedMasks, (element) => element.value));
+  }
+}
+
+/**
+ * Save shown masks to storage.
+ * @param {Iterable<string>} shownMasks
+ */
+function saveShownMasks(shownMasks) {
+  const serialized = Array.from(shownMasks).join(',');
+  localStorage.setItem('shownMasks', serialized);
+}
+
+const savedMasks = loadShownMasks();
+
+form.addEventListener('change', (event) => {
+  const input = /** @type {HTMLInputElement} */ (event.target);
+  if (input.name === 'mask') {
+    if (input.checked) {
+      savedMasks.add(input.value);
+    } else {
+      savedMasks.delete(input.value);
+    }
+    saveShownMasks(savedMasks);
+  }
+});

--- a/src/viewer/change-mask.js
+++ b/src/viewer/change-mask.js
@@ -1,3 +1,4 @@
+// @ts-check
 import { applyMask } from './masks.js';
 
 if ('serviceWorker' in navigator) {
@@ -5,9 +6,41 @@ if ('serviceWorker' in navigator) {
   navigator.serviceWorker.register('/sw.js');
 }
 
-if (new URL(location.href).searchParams.has('secret')) {
-  // Secret masks with poor support
-  document.body.classList.add('show-secrets');
+class MaskManager {
+  constructor() {
+    this.container = document.querySelector('.masks');
+    this.hideMasks();
+  }
+
+  /**
+   * @type {NodeListOf<HTMLInputElement>}
+   */
+  get masks() {
+    return this.container.querySelectorAll('.mask__option input');
+  }
+
+  /**
+   * Get hidden masks from storage. Defaults to masks that aren't well supported.
+   * @private
+   * @returns {readonly string[]}
+   */
+  getHiddenMasks() {
+    const hiddenMasksList = localStorage.getItem('hiddenMasks');
+    if (hiddenMasksList != undefined) {
+      return hiddenMasksList.split(',');
+    } else {
+      /** @type {NodeListOf<HTMLInputElement>} */
+      const poorSupportMaskInputs = this.container.querySelectorAll('.mask--path input');
+      return Array.from(poorSupportMaskInputs, element => element.value);
+    }
+  }
+
+  hideMasks() {
+    const toHide = new Set(this.getHiddenMasks())
+    for (const mask of this.masks) {
+      mask.parentElement.hidden = toHide.has(mask.value);
+    }
+  }
 }
 
 /** @type {HTMLElement} */
@@ -17,7 +50,8 @@ const masked = document.querySelectorAll('.masked');
 /** @type {NodeListOf<HTMLElement>} */
 const icons = document.querySelectorAll('.icon');
 
-document.querySelector('.masks').addEventListener('change', (evt) => {
+const maskManager = new MaskManager();
+maskManager.container.addEventListener('change', (evt) => {
   const radio = /** @type {HTMLInputElement} */ (evt.target);
   if (radio.name === 'mask') {
     applyMask(masked, icons, radio.value);

--- a/src/viewer/change-mask.js
+++ b/src/viewer/change-mask.js
@@ -24,21 +24,22 @@ class MaskManager {
    * @private
    * @returns {readonly string[]}
    */
-  getHiddenMasks() {
-    const hiddenMasksList = localStorage.getItem('hiddenMasks');
-    if (hiddenMasksList != undefined) {
-      return hiddenMasksList.split(',');
+  getShownMasks() {
+    const shownMasks = localStorage.getItem('shownMasks');
+    if (shownMasks != undefined) {
+      return shownMasks.split(',');
     } else {
-      /** @type {NodeListOf<HTMLInputElement>} */
-      const poorSupportMaskInputs = this.container.querySelectorAll('.mask--path input');
-      return Array.from(poorSupportMaskInputs, element => element.value);
+      undefined;
     }
   }
 
   hideMasks() {
-    const toHide = new Set(this.getHiddenMasks())
-    for (const mask of this.masks) {
-      mask.parentElement.hidden = toHide.has(mask.value);
+    const shownMasks = this.getShownMasks();
+    if (shownMasks) {
+      const toShow = new Set(this.getShownMasks());
+      for (const mask of this.masks) {
+        mask.parentElement.hidden = !toShow.has(mask.value);
+      }
     }
   }
 }

--- a/src/viewer/upload-icon.js
+++ b/src/viewer/upload-icon.js
@@ -1,6 +1,8 @@
-const imgElements = /** @type {HTMLCollectionOf<HTMLImageElement>} */ (
-  document.getElementsByClassName('icon')
-);
+const imgElements =
+  /** @type {HTMLCollectionOf<HTMLImageElement | SVGImageElement>} */ (
+    document.getElementsByClassName('icon')
+  );
+const lastImg = /** @type {HTMLImageElement} */ (imgElements[0]);
 
 /**
  * Changes the displayed icon in the center of the screen.
@@ -14,7 +16,7 @@ function updateDisplayedIcon(source) {
   if (!source) return;
 
   // Revoke the old URL
-  const oldUrl = imgElements[0].src;
+  const oldUrl = lastImg.src;
   if (oldUrl.startsWith('blob:')) {
     URL.revokeObjectURL(oldUrl);
   }
@@ -31,7 +33,11 @@ function updateDisplayedIcon(source) {
   updateSource(source);
   for (let i = 0; i < imgElements.length; i++) {
     const imgElement = imgElements[i];
-    imgElement.src = source;
+    if (imgElement instanceof SVGImageElement) {
+      imgElement.setAttribute('href', source);
+    } else {
+      imgElement.src = source;
+    }
   }
 }
 
@@ -47,6 +53,8 @@ function updateDisplayedIcon(source) {
 function updateSource(source) {
   /** @type {HTMLElement} */
   const sourceDisplay = document.querySelector('.source');
+  if (!sourceDisplay) return;
+
   /** @type {HTMLAnchorElement} */
   const sourceLink = sourceDisplay.querySelector('.source__link');
 
@@ -66,33 +74,35 @@ const fileInput = document.querySelector('#icon_file');
 /** @type {import('file-drop-element').FileDropElement} The invisible file drop area */
 const fileDrop = document.querySelector('#icon_drop');
 
-/** @type {AddEventListenerOptions} */
-const pas = { passive: true };
+if (fileInput) {
+  /** @type {AddEventListenerOptions} */
+  const pas = { passive: true };
 
-// Update the displayed icon when the "Open icon file" button is used
-fileInput.addEventListener(
-  'change',
-  () => updateDisplayedIcon(fileInput.files[0]),
-  pas
-);
-// Update the displayed icon when a file is dropped in
-fileDrop.addEventListener(
-  'filedrop',
-  (evt) => updateDisplayedIcon(evt.files[0]),
-  pas
-);
+  // Update the displayed icon when the "Open icon file" button is used
+  fileInput.addEventListener(
+    'change',
+    () => updateDisplayedIcon(fileInput.files[0]),
+    pas
+  );
+  // Update the displayed icon when a file is dropped in
+  fileDrop.addEventListener(
+    'filedrop',
+    (evt) => updateDisplayedIcon(evt.files[0]),
+    pas
+  );
 
-// File input focus polyfill for Firefox
-fileInput.addEventListener(
-  'focus',
-  () => fileInput.classList.add('focus'),
-  pas
-);
-fileInput.addEventListener(
-  'blur',
-  () => fileInput.classList.remove('focus'),
-  pas
-);
+  // File input focus polyfill for Firefox
+  fileInput.addEventListener(
+    'focus',
+    () => fileInput.classList.add('focus'),
+    pas
+  );
+  fileInput.addEventListener(
+    'blur',
+    () => fileInput.classList.remove('focus'),
+    pas
+  );
+}
 
 // If there's a URL present in the "?demo" query parameter, use it as the icon URL.
 const demoUrl = new URL(location.href).searchParams.get('demo');
@@ -100,14 +110,16 @@ updateDisplayedIcon(demoUrl);
 
 /** @type {HTMLUListElement} */
 const demoLinks = document.querySelector('.demo__list');
-demoLinks.addEventListener('click', (evt) => {
-  const target = /** @type {HTMLElement} */ (evt.target);
-  const link = /** @type {HTMLAnchorElement | null} */ (
-    target.closest('.demo__link')
-  );
-  if (link != undefined) {
-    evt.preventDefault();
-    const demoUrl = new URL(link.href).searchParams.get('demo');
-    updateDisplayedIcon(demoUrl);
-  }
-});
+if (demoLinks) {
+  demoLinks.addEventListener('click', (evt) => {
+    const target = /** @type {HTMLElement} */ (evt.target);
+    const link = /** @type {HTMLAnchorElement | null} */ (
+      target.closest('.demo__link')
+    );
+    if (link != undefined) {
+      evt.preventDefault();
+      const demoUrl = new URL(link.href).searchParams.get('demo');
+      updateDisplayedIcon(demoUrl);
+    }
+  });
+}


### PR DESCRIPTION
Fixes #68
Fixes #18

Adds a new /settings page to control which masks show up. I wanted to have this in place before allowing the SVG path based masks for general use.
