### PR TITLE
feat(docker): add production-ready Dockerfile and docker-compose setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+# Build stage
+FROM node:20-slim AS build
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+# Runtime stage with Nginx
+FROM nginx:alpine AS runner
+COPY --from=build /app/dist /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,6 @@ services:
   maskable-app:
     build: .
     ports:
-      - "5173:80"
+      - "8080:80"
     environment:
       - NODE_ENV=production

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+services:
+  maskable-app:
+    build: .
+    ports:
+      - "5173:80"
+    environment:
+      - NODE_ENV=production


### PR DESCRIPTION
This PR adds a production-ready Docker setup:

- Multi-stage Dockerfile with Node.js 20 (slim) for build and Nginx (alpine) for runtime
- docker-compose.yml for local orchestration
  - Builds the app from the Dockerfile
  - Maps host port 8080 to container port 80
  - Sets NODE_ENV=production